### PR TITLE
Chore/update prod api endpoints

### DIFF
--- a/command-line-demos/activity-monitor/quickstart.py
+++ b/command-line-demos/activity-monitor/quickstart.py
@@ -30,7 +30,6 @@ DEFAULT_MAX_RUN_SEC = 600.0
 DEFAULT_MAX_NEW_TOKENS = 256
 DEFAULT_STEP_SIZE = 60
 DEFAULT_WINDOW_SIZE = 60
-DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 
 # ---------- Interactive inputs ----------
 def get_user_inputs() -> dict:
@@ -38,6 +37,7 @@ def get_user_inputs() -> dict:
     print("\n=== Activity Monitor ===\n")
 
     api_key = os.getenv("ATAI_API_KEY", "").strip() or input("Enter your ArchetypeAI API key: ").strip()
+    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint: ").strip()
     if not api_key:
         print("Error: API key is required."); sys.exit(1)
 
@@ -77,7 +77,7 @@ def get_user_inputs() -> dict:
         "video_file_id": None,          # filled later if video
         "step_size": DEFAULT_STEP_SIZE,
         "window_size": DEFAULT_WINDOW_SIZE,
-        "api_endpoint": DEFAULT_API_ENDPOINT,
+        "api_endpoint": api_endpoint,
     }
 
 # ---------- Event builders ----------

--- a/command-line-demos/activity-monitor/quickstart.py
+++ b/command-line-demos/activity-monitor/quickstart.py
@@ -37,7 +37,7 @@ def get_user_inputs() -> dict:
     print("\n=== Activity Monitor ===\n")
 
     api_key = os.getenv("ATAI_API_KEY", "").strip() or input("Enter your ArchetypeAI API key: ").strip()
-    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint: ").strip()
+    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint (Press Enter for default): ").strip() or ArchetypeAI.get_default_endpoint()
     if not api_key:
         print("Error: API key is required."); sys.exit(1)
 

--- a/command-line-demos/activity-monitor/quickstart.py
+++ b/command-line-demos/activity-monitor/quickstart.py
@@ -24,12 +24,11 @@ def colorize_text(text: str, red: int = 164, green: int = 186, blue: int = 250) 
     return f"\033[38;2;{red};{green};{blue}m{text}\033[0m"
 
 # ---------- Setup ----------
-DEFAULT_LENS_ID = "lns-fd669361822b07e2-bc718aa3fdf0b3b7"
 DEFAULT_INSTRUCTION = "Answer the following question about the video in less than 15 words:"
 DEFAULT_MAX_RUN_SEC = 600.0
 DEFAULT_MAX_NEW_TOKENS = 256
-DEFAULT_STEP_SIZE = 60
-DEFAULT_WINDOW_SIZE = 60
+DEFAULT_STEP_SIZE = 30
+DEFAULT_TEMPORAL_FOCUS = 5
 
 # ---------- Interactive inputs ----------
 def get_user_inputs() -> dict:
@@ -61,8 +60,10 @@ def get_user_inputs() -> dict:
                 rtsp_url = u; break
             print("Please enter a valid rtsp:// or rtsps:// URL.")
 
-    focus = input("\nWhat would you like to know about the video? ").strip() or "Describe the video."
-    instruction = DEFAULT_INSTRUCTION
+    focus = input("\nEnter focus (what to look for): ").strip() or "Describe the video."
+
+    temporal_focus_input = input(f"Temporal focus (default: {DEFAULT_TEMPORAL_FOCUS}): ").strip()
+    temporal_focus = int(temporal_focus_input) if temporal_focus_input.isdigit() else DEFAULT_TEMPORAL_FOCUS
 
     return {
         "api_key": api_key,
@@ -70,85 +71,26 @@ def get_user_inputs() -> dict:
         "video_file_path": video_file_path,
         "rtsp_url": rtsp_url,
         "focus": focus,
-        "instruction": instruction,
+        "instruction": DEFAULT_INSTRUCTION,
         "max_run_time_sec": DEFAULT_MAX_RUN_SEC,
         "max_new_tokens": DEFAULT_MAX_NEW_TOKENS,
-        "lens_id": DEFAULT_LENS_ID,
-        "video_file_id": None,          # filled later if video
         "step_size": DEFAULT_STEP_SIZE,
-        "window_size": DEFAULT_WINDOW_SIZE,
+        "temporal_focus": temporal_focus,
         "api_endpoint": api_endpoint,
     }
 
-# ---------- Event builders ----------
-def build_input_event(args: dict) -> dict:
-    if args["input_type"] == "rtsp":
-        return {
-            "type": "input_stream.set",
-            "event_data": {
-                "stream_type": "rtsp_video_reader",
-                "stream_config": {
-                    "rtsp_url": args["rtsp_url"],
-                    "target_image_size": [360, 640],
-                    "target_frame_rate_hz": 1.0,
-                }
-            }
-        }
-    else:
-        return {
-            "type": "input_stream.set",
-            "event_data": {
-                "stream_type": "video_file_reader",
-                "stream_config": {
-                    "file_id": args["video_file_id"],
-                    "step_size": args["step_size"],
-                    "window_size": args["window_size"],
-                }
-            }
-        }
 
-def build_focus_event(args: dict) -> dict:
-    return {
-        "type": "session.modify",
-        "event_data": {
-            "focus": args["focus"],
-            "max_new_tokens": args["max_new_tokens"],
-            "instruction": args["instruction"]
-        }
-    }
+def session_callback(
+        session_id: str,
+        session_endpoint: str,
+        client: ArchetypeAI,
+        args: dict
+    ) -> None:
+    """Main function to run the logic of a custom lens session."""
 
-def build_output_event() -> dict:
-    return {
-        "type": "output_stream.set",
-        "event_data": {
-            "stream_type": "server_side_events_writer",
-            "stream_config": {},
-        }
-    }
-
-# ---------- Session ----------
-def session_fn(session_id: str, session_endpoint: str, client: ArchetypeAI, args: dict) -> None:
-    print(f"Session created: {session_id}")
-
-    # If using a video file, upload it now (after session start)
-    if args["input_type"] == "video" and args.get("video_file_path"):
-        print(f"Uploading video: {args['video_file_path']}")
-        try:
-            resp = client.files.local.upload(args["video_file_path"])
-            args["video_file_id"] = resp.get("file_id")
-            if not args["video_file_id"]:
-                print("Error: no file_id returned."); return
-        except Exception as e:
-            print(f"Error: Failed to upload video: {e}")
-            return
-
-    # Configure streams and focus
-    client.lens.sessions.process_event(session_id, build_input_event(args))
-    client.lens.sessions.process_event(session_id, build_focus_event(args))
-    client.lens.sessions.process_event(session_id, build_output_event())
-
-    # SSE reader
-    sse_reader = client.lens.sessions.create_sse_consumer(session_id, max_read_time_sec=args["max_run_time_sec"])
+    # Create a SSE reader to read the output of the lens.
+    sse_reader = client.lens.sessions.create_sse_consumer(
+        session_id, max_read_time_sec=args["max_run_time_sec"])
 
     print(f"\nMonitoring started — looking for: '{args['focus']}'")
     print("Press Ctrl+C to stop\n")
@@ -158,6 +100,8 @@ def session_fn(session_id: str, session_endpoint: str, client: ArchetypeAI, args
     signal.signal(signal.SIGINT, _sigint)
 
     try:
+        # Read events from the SSE stream until either the last message is
+        # received or the max read time has been reached.
         for event in sse_reader.read(block=True):
             if stop["flag"]:
                 break
@@ -168,6 +112,7 @@ def session_fn(session_id: str, session_endpoint: str, client: ArchetypeAI, args
                 if resp and isinstance(resp, list):
                     print(f"{ts}: {resp[0]}")
     finally:
+        # Close any active reader.
         sse_reader.close()
         print("Stopped.")
 
@@ -187,8 +132,43 @@ def main():
 
     input("\nPress Enter to start monitoring...")
 
-    # Start session;
-    client.lens.create_and_run_session(args["lens_id"], session_fn, auto_destroy=True, client=client, args=args)
+    # Upload the video file to the archetype platform if using video input.
+    if args["input_type"] == "video":
+        print(f"Uploading video: {args['video_file_path']}")
+        try:
+            file_response = client.files.local.upload(args["video_file_path"])
+            video_file_id = file_response["file_id"]
+        except Exception as e:
+            print(f"Error: Failed to upload video: {e}")
+            return
+
+        input_streams_config = f"""
+            - stream_type: video_file_reader
+              stream_config:
+                file_id: {video_file_id}
+                step_size: {args['step_size']}"""
+    else:
+        input_streams_config = f"""
+            - stream_type: rtsp_video_reader
+              stream_config:
+                rtsp_url: "{args['rtsp_url']}"
+                target_image_size: [360, 640]
+                target_frame_rate_hz: 1.0"""
+
+    # Create a custom lens and automatically launch the lens session.
+    client.lens.create_and_run_lens(f"""
+       lens_name: Custom Activity Monitor
+       lens_config:
+        model_parameters:
+            model_version: Newton::c2_3_7b_2508014e10af56
+            instruction: "{args['instruction']}"
+            focus: "{args['focus']}"
+            temporal_focus: {args['temporal_focus']}
+            max_new_tokens: {args['max_new_tokens']}
+        input_streams:{input_streams_config}
+        output_streams:
+            - stream_type: server_sent_events_writer
+    """, session_callback, client=client, args=args)
     print("Session finished.")
 
 if __name__ == "__main__":

--- a/command-line-demos/activity-monitor/quickstart.py
+++ b/command-line-demos/activity-monitor/quickstart.py
@@ -30,6 +30,7 @@ DEFAULT_MAX_RUN_SEC = 600.0
 DEFAULT_MAX_NEW_TOKENS = 256
 DEFAULT_STEP_SIZE = 60
 DEFAULT_WINDOW_SIZE = 60
+DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 
 # ---------- Interactive inputs ----------
 def get_user_inputs() -> dict:
@@ -76,6 +77,7 @@ def get_user_inputs() -> dict:
         "video_file_id": None,          # filled later if video
         "step_size": DEFAULT_STEP_SIZE,
         "window_size": DEFAULT_WINDOW_SIZE,
+        "api_endpoint": DEFAULT_API_ENDPOINT,
     }
 
 # ---------- Event builders ----------
@@ -172,9 +174,10 @@ def session_fn(session_id: str, session_endpoint: str, client: ArchetypeAI, args
 # ---------- Main ----------
 def main():
     args = get_user_inputs()
-    client = ArchetypeAI(args["api_key"], api_endpoint=ArchetypeAI.get_default_endpoint())
+    client = ArchetypeAI(args["api_key"], api_endpoint=args["api_endpoint"])
 
     print("\n--- Configuration Summary ---")
+    print(f"API Endpoint: {args['api_endpoint']} ")
     print(f"Input:  {args['input_type'].upper()}")
     if args['input_type'] == 'rtsp':
         print(f"RTSP:   {args['rtsp_url']}")

--- a/command-line-demos/machine-state/quickstart.py
+++ b/command-line-demos/machine-state/quickstart.py
@@ -28,7 +28,7 @@ def colorize_text(text: str, red: int = 164, green: int = 186, blue: int = 250) 
 
 # ---------- Defaults ----------
 DEFAULT_LENS_ID = "lns-1d519091822706e2-bc108andqxf8b4os"
-DEFAULT_API_ENDPOINT = "https://api.archetypeai.dev/v0.5"
+DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 DEFAULT_MAX_RUN_SEC = 600.0
 DEFAULT_WINDOW_SIZE = 1024
 DEFAULT_STEP_SIZE = 1024  # no overlap
@@ -171,7 +171,7 @@ def main():
 
     print("\n--- Configuration Summary ---")
     print(f"Lens ID:      {args['lens_id']}")
-    print(f"API Endpoint: {args['api_endpoint']}")
+    print(f"API Endpoint: {args["api_endpoint"]}")
     print(f"Data file:    {args['data_file_path']}")
     print(f"Classes:      {len(args['focus_files'])}")
     for cls, p in args["focus_files"].items():

--- a/command-line-demos/machine-state/quickstart.py
+++ b/command-line-demos/machine-state/quickstart.py
@@ -74,7 +74,7 @@ def get_user_inputs() -> dict:
     print("\n=== Machine State Lens ===\n")
 
     api_key = os.getenv("ATAI_API_KEY", "").strip() or input("Enter your API key: ").strip()
-    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint: ").strip()
+    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint (Press Enter for default): ").strip() or ArchetypeAI.get_default_endpoint()
     if not api_key:
         print("Error: API key is required."); sys.exit(1)
 

--- a/command-line-demos/machine-state/quickstart.py
+++ b/command-line-demos/machine-state/quickstart.py
@@ -28,7 +28,6 @@ def colorize_text(text: str, red: int = 164, green: int = 186, blue: int = 250) 
 
 # ---------- Defaults ----------
 DEFAULT_LENS_ID = "lns-1d519091822706e2-bc108andqxf8b4os"
-DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 DEFAULT_MAX_RUN_SEC = 600.0
 DEFAULT_WINDOW_SIZE = 1024
 DEFAULT_STEP_SIZE = 1024  # no overlap
@@ -75,6 +74,7 @@ def get_user_inputs() -> dict:
     print("\n=== Machine State Lens ===\n")
 
     api_key = os.getenv("ATAI_API_KEY", "").strip() or input("Enter your API key: ").strip()
+    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint: ").strip()
     if not api_key:
         print("Error: API key is required."); sys.exit(1)
 
@@ -116,7 +116,7 @@ def get_user_inputs() -> dict:
         "window_size": window_size,
         "step_size": step_size,
         "lens_id": DEFAULT_LENS_ID,
-        "api_endpoint": DEFAULT_API_ENDPOINT,
+        "api_endpoint": api_endpoint,
         "max_run_time_sec": DEFAULT_MAX_RUN_SEC,
     }
 

--- a/spreadsheet-analysis/cl-to-sheets/app.py
+++ b/spreadsheet-analysis/cl-to-sheets/app.py
@@ -32,7 +32,6 @@ print(BANNER)
 
 # ---------- Defaults ----------
 DEFAULT_LENS_ID = "lns-1d519091822706e2-bc108andqxf8b4os"
-DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 DEFAULT_MAX_RUN_SEC = 600.0
 DEFAULT_WINDOW_SIZE = 1024
 DEFAULT_STEP_SIZE = 1024  # no overlap
@@ -155,6 +154,7 @@ def get_user_inputs() -> dict:
     print("\n=== Machine State → Google Sheets ===\n")
 
     api_key = os.getenv("ATAI_API_KEY", "").strip() or input("Enter your ArchetypeAI API key: ").strip()
+    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint: ").strip()
     if not api_key:
         print("Error: API key is required."); sys.exit(1)
 
@@ -198,7 +198,7 @@ def get_user_inputs() -> dict:
         "window_size": window_size,
         "step_size": step_size,
         "lens_id": DEFAULT_LENS_ID,
-        "api_endpoint": DEFAULT_API_ENDPOINT,
+        "api_endpoint": api_endpoint,
         "max_run_time_sec": DEFAULT_MAX_RUN_SEC,
     }
 

--- a/spreadsheet-analysis/cl-to-sheets/app.py
+++ b/spreadsheet-analysis/cl-to-sheets/app.py
@@ -154,7 +154,7 @@ def get_user_inputs() -> dict:
     print("\n=== Machine State → Google Sheets ===\n")
 
     api_key = os.getenv("ATAI_API_KEY", "").strip() or input("Enter your ArchetypeAI API key: ").strip()
-    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint: ").strip()
+    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint (Press Enter for default): ").strip() or ArchetypeAI.get_default_endpoint()
     if not api_key:
         print("Error: API key is required."); sys.exit(1)
 

--- a/spreadsheet-analysis/cl-to-sheets/app.py
+++ b/spreadsheet-analysis/cl-to-sheets/app.py
@@ -32,7 +32,7 @@ print(BANNER)
 
 # ---------- Defaults ----------
 DEFAULT_LENS_ID = "lns-1d519091822706e2-bc108andqxf8b4os"
-DEFAULT_API_ENDPOINT = "https://api.archetypeai.dev/v0.5"
+DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 DEFAULT_MAX_RUN_SEC = 600.0
 DEFAULT_WINDOW_SIZE = 1024
 DEFAULT_STEP_SIZE = 1024  # no overlap

--- a/telegram-alerts/bot_only/app.py
+++ b/telegram-alerts/bot_only/app.py
@@ -32,7 +32,6 @@ print(BANNER)
 
 # ---------- Lens Config ----------
 LENS_ID = "lns-fd669361822b07e2-bc718aa3fdf0b3b7"
-
 DEFAULT_INSTRUCTION = (
     "STOP. FOLLOW THIS EXACT FORMAT: Step 1: Write <scan> I see in this video: "
     "then list ALL detected objects, vehicles, people, animals, buildings, and their "
@@ -44,6 +43,7 @@ DEFAULT_INSTRUCTION = (
     "Alert: short description of what was detected, max 15 words ONLY return one of the above. "
     "Do not describe anything else."
 )
+DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 
 # ---------- Telegram Config ----------
 BOT_TOKEN = "YOUR_BOT_TOCKEN"
@@ -158,11 +158,12 @@ def start_monitoring(api_key, input_type, rtsp_url, video_file_id, focus):
         "input_type": input_type,
         "focus": focus,
         "instruction": DEFAULT_INSTRUCTION,
-        "max_run_time_sec": 600.0
+        "max_run_time_sec": 600.0,
+        "api_endpoint": DEFAULT_API_ENDPOINT
     }
     last_args = args.copy()
 
-    client = ArchetypeAI(api_key, api_endpoint=ArchetypeAI.get_default_endpoint())
+    client = ArchetypeAI(args["api_key"], api_endpoint=args["api_endpoint"])
     current_client = client
     send_telegram_alert(f"Monitoring started with focus: {focus}")
 

--- a/telegram-alerts/bot_only/app.py
+++ b/telegram-alerts/bot_only/app.py
@@ -31,7 +31,6 @@ BANNER = r"""
 print(BANNER)
 
 # ---------- Lens Config ----------
-LENS_ID = "lns-fd669361822b07e2-bc718aa3fdf0b3b7"
 DEFAULT_INSTRUCTION = (
     "STOP. FOLLOW THIS EXACT FORMAT: Step 1: Write <scan> I see in this video: "
     "then list ALL detected objects, vehicles, people, animals, buildings, and their "
@@ -43,6 +42,9 @@ DEFAULT_INSTRUCTION = (
     "Alert: short description of what was detected, max 15 words ONLY return one of the above. "
     "Do not describe anything else."
 )
+DEFAULT_STEP_SIZE = 30
+DEFAULT_TEMPORAL_FOCUS = 5
+DEFAULT_MAX_NEW_TOKENS = 256
 
 # ---------- Telegram Config ----------
 BOT_TOKEN = "YOUR_BOT_TOCKEN"
@@ -67,60 +69,13 @@ current_client = None
 current_session_id = None
 last_args = {}
 
-# ---------- Session Handling ----------
-def session_fn(session_id, session_endpoint, client, args):
+def session_callback(session_id, session_endpoint, client, args):
+    """Main function to run the logic of a custom lens session."""
     global last_alert_state, stop_flag
 
-    # --- Input stream
-    if args["input_type"] == "rtsp":
-        event = {
-            "type": "input_stream.set",
-            "event_data": {
-                "stream_type": "rtsp_video_reader",
-                "stream_config": {
-                    "rtsp_url": args["rtsp_url"],
-                    "target_image_size": [360, 640],
-                    "target_frame_rate_hz": 1.0,
-                }
-            }
-        }
-    else:
-        event = {
-            "type": "input_stream.set",
-            "event_data": {
-                "stream_type": "video_file_reader",
-                "stream_config": {
-                    "file_id": args["video_file_id"],
-                    "step_size": 60,
-                    "window_size": 1
-                }
-            }
-        }
-    response = client.lens.sessions.process_event(session_id, event)
-    logging.info(f"Stream response:\n{pformat(response, indent=4)}")
-
-    # --- Focus & instruction
-    event = {
-        "type": "session.modify",
-        "event_data": {
-            "focus": args["focus"],
-            "max_new_tokens": 256,
-            "instruction": args["instruction"]
-        }
-    }
-    response = client.lens.sessions.process_event(session_id, event)
-    logging.info(f"Instruction response:\n{pformat(response, indent=4)}")
-
-    # --- Output stream
-    event = {
-        "type": "output_stream.set",
-        "event_data": {"stream_type": "server_side_events_writer", "stream_config": {}}
-    }
-    response = client.lens.sessions.process_event(session_id, event)
-    logging.info(f"Output stream response:\n{pformat(response, indent=4)}")
-
-    # --- SSE Reader
+    # Create a SSE reader to read the output of the lens.
     sse_reader = client.lens.sessions.create_sse_consumer(session_id, max_read_time_sec=args["max_run_time_sec"])
+
     for event in sse_reader.read(block=True):
         if stop_flag:
             logging.info("🛑 Monitoring stopped.")
@@ -142,6 +97,7 @@ def session_fn(session_id, session_endpoint, client, args):
 
                 last_alert_state = is_alert
 
+    # Close any active reader.
     sse_reader.close()
 
 # ---------- Monitoring Control ----------
@@ -158,7 +114,10 @@ def start_monitoring(api_key, api_endpoint, input_type, rtsp_url, video_file_id,
         "focus": focus,
         "instruction": DEFAULT_INSTRUCTION,
         "max_run_time_sec": 600.0,
-        "api_endpoint": api_endpoint
+        "api_endpoint": api_endpoint,
+        "step_size": DEFAULT_STEP_SIZE,
+        "temporal_focus": DEFAULT_TEMPORAL_FOCUS,
+        "max_new_tokens": DEFAULT_MAX_NEW_TOKENS
     }
     last_args = args.copy()
 
@@ -166,12 +125,43 @@ def start_monitoring(api_key, api_endpoint, input_type, rtsp_url, video_file_id,
     current_client = client
     send_telegram_alert(f"Monitoring started with focus: {focus}")
 
+    # Handle video file ID
+    if input_type == "video":
+        file_id = video_file_id
+        logging.info(f"Using file ID: {file_id}")
+
+        input_streams_config = f"""
+            - stream_type: video_file_reader
+              stream_config:
+                file_id: {file_id}
+                step_size: {args['step_size']}"""
+    else:
+        input_streams_config = f"""
+            - stream_type: rtsp_video_reader
+              stream_config:
+                rtsp_url: "{args['rtsp_url']}"
+                target_image_size: [360, 640]
+                target_frame_rate_hz: 1.0"""
+
     def wrapper(session_id, session_endpoint, client, args):
         global current_session_id
         current_session_id = session_id
-        session_fn(session_id, session_endpoint, client, args)
+        session_callback(session_id, session_endpoint, client, args)
 
-    client.lens.create_and_run_session(LENS_ID, wrapper, auto_destroy=True, client=client, args=args)
+    # Create a custom lens and automatically launch the lens session.
+    client.lens.create_and_run_lens(f"""
+       lens_name: Custom Telegram Activity Monitor
+       lens_config:
+        model_parameters:
+            model_version: Newton::c2_3_7b_2508014e10af56
+            instruction: "{args['instruction']}"
+            focus: "{args['focus']}"
+            temporal_focus: {args['temporal_focus']}
+            max_new_tokens: {args['max_new_tokens']}
+        input_streams:{input_streams_config}
+        output_streams:
+            - stream_type: server_sent_events_writer
+    """, wrapper, client=client, args=args)
 
 def stop_monitoring():
     """Stop and destroy the current session properly."""

--- a/telegram-alerts/bot_only/app.py
+++ b/telegram-alerts/bot_only/app.py
@@ -43,7 +43,6 @@ DEFAULT_INSTRUCTION = (
     "Alert: short description of what was detected, max 15 words ONLY return one of the above. "
     "Do not describe anything else."
 )
-DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 
 # ---------- Telegram Config ----------
 BOT_TOKEN = "YOUR_BOT_TOCKEN"
@@ -146,7 +145,7 @@ def session_fn(session_id, session_endpoint, client, args):
     sse_reader.close()
 
 # ---------- Monitoring Control ----------
-def start_monitoring(api_key, input_type, rtsp_url, video_file_id, focus):
+def start_monitoring(api_key, api_endpoint, input_type, rtsp_url, video_file_id, focus):
     """Start a new monitoring session."""
     global stop_flag, current_client, current_session_id, last_args
     stop_flag = False
@@ -159,7 +158,7 @@ def start_monitoring(api_key, input_type, rtsp_url, video_file_id, focus):
         "focus": focus,
         "instruction": DEFAULT_INSTRUCTION,
         "max_run_time_sec": 600.0,
-        "api_endpoint": DEFAULT_API_ENDPOINT
+        "api_endpoint": api_endpoint
     }
     last_args = args.copy()
 
@@ -202,7 +201,7 @@ def restart_with_new_focus(new_focus):
 
     monitoring_thread = threading.Thread(
         target=start_monitoring,
-        args=(last_args["api_key"], last_args["input_type"], last_args["rtsp_url"], last_args["video_file_id"], last_args["focus"]),
+        args=(last_args["api_key"], last_args["api_endpoint"], last_args["input_type"], last_args["rtsp_url"], last_args["video_file_id"], last_args["focus"]),
         daemon=True
     )
     monitoring_thread.start()
@@ -211,7 +210,7 @@ def restart_with_new_focus(new_focus):
 async def start_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text(
         "Commands:\n"
-        "/start_monitoring <api_key> <rtsp|video> <url_or_id> <focus>\n"
+        "/start_monitoring <api_key> <api_endpoint> <rtsp|video> <url_or_id> <focus>\n"
         "/stop_monitoring\n"
         "/change_focus <new focus>\n"
         "/status"
@@ -223,17 +222,17 @@ async def start_monitoring_cmd(update: Update, context: ContextTypes.DEFAULT_TYP
         await update.message.reply_text("⚠️ Already running. Use /stop_monitoring first.")
         return
 
-    if len(context.args) < 4:
-        await update.message.reply_text("Usage: /start_monitoring <api_key> <rtsp|video> <url_or_id> <focus>")
+    if len(context.args) < 5:
+        await update.message.reply_text("Usage: /start_monitoring <api_key> <api_endpoint> <rtsp|video> <url_or_id> <focus>")
         return
 
-    api_key, input_type, url_or_id, *focus_words = context.args
+    api_key, api_endpoint, input_type, url_or_id, *focus_words = context.args
     focus = " ".join(focus_words)
     rtsp_url, video_file_id = (url_or_id, None) if input_type == "rtsp" else (None, url_or_id)
 
     monitoring_thread = threading.Thread(
         target=start_monitoring,
-        args=(api_key, input_type, rtsp_url, video_file_id, focus),
+        args=(api_key, api_endpoint, input_type, rtsp_url, video_file_id, focus),
         daemon=True
     )
     monitoring_thread.start()

--- a/telegram-alerts/terminal_bot/app.py
+++ b/telegram-alerts/terminal_bot/app.py
@@ -27,7 +27,6 @@ print(BANNER)
 
 # ---------- Lens Config ----------
 LENS_ID = "lns-fd669361822b07e2-bc718aa3fdf0b3b7"
-
 DEFAULT_INSTRUCTION = (
     "STOP. FOLLOW THIS EXACT FORMAT: Step 1: Write <scan> I see in this video: "
     "then list ALL detected objects, vehicles, people, animals, buildings, and their "
@@ -39,6 +38,7 @@ DEFAULT_INSTRUCTION = (
     "Alert: short description of what was detected, max 15 words ONLY return one of the above. "
     "Do not describe anything else."
 )
+DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 
 # ---------- Telegram Config ----------
 BOT_TOKEN = "YOUR_BOT_TOCKEN"
@@ -163,9 +163,10 @@ def main():
         "focus": focus,
         "instruction": DEFAULT_INSTRUCTION,
         "max_run_time_sec": 600.0,
+        "api_endpoint": DEFAULT_API_ENDPOINT
     }
 
-    client = ArchetypeAI(api_key, api_endpoint=ArchetypeAI.get_default_endpoint())
+    client = ArchetypeAI(args["api_key"], api_endpoint=args["api_endpoint"])
     logging.info("▶️ Starting monitoring session…")
     send_telegram_alert("▶️ Smart monitoring started…")
 

--- a/telegram-alerts/terminal_bot/app.py
+++ b/telegram-alerts/terminal_bot/app.py
@@ -26,7 +26,6 @@ BANNER = r"""
 print(BANNER)
 
 # ---------- Lens Config ----------
-LENS_ID = "lns-fd669361822b07e2-bc718aa3fdf0b3b7"
 DEFAULT_INSTRUCTION = (
     "STOP. FOLLOW THIS EXACT FORMAT: Step 1: Write <scan> I see in this video: "
     "then list ALL detected objects, vehicles, people, animals, buildings, and their "
@@ -38,6 +37,9 @@ DEFAULT_INSTRUCTION = (
     "Alert: short description of what was detected, max 15 words ONLY return one of the above. "
     "Do not describe anything else."
 )
+DEFAULT_STEP_SIZE = 30
+DEFAULT_TEMPORAL_FOCUS = 5
+DEFAULT_MAX_NEW_TOKENS = 256
 
 # ---------- Telegram Config ----------
 BOT_TOKEN = "YOUR_BOT_TOCKEN"
@@ -58,60 +60,13 @@ def send_telegram_alert(message: str) -> None:
 # ---------- State ----------
 last_alert_state = False  # toggles when we first see an “Alert: …” line
 
-# ---------- Session Handling ----------
-def session_fn(session_id, session_endpoint, client: ArchetypeAI, args: dict) -> None:
+def session_callback(session_id, session_endpoint, client: ArchetypeAI, args: dict) -> None:
+    """Main function to run the logic of a custom lens session."""
     global last_alert_state
 
-    # Input stream (RTSP or already-uploaded video file ID)
-    if args["input_type"] == "rtsp":
-        event = {
-            "type": "input_stream.set",
-            "event_data": {
-                "stream_type": "rtsp_video_reader",
-                "stream_config": {
-                    "rtsp_url": args["rtsp_url"],
-                    "target_image_size": [360, 640],
-                    "target_frame_rate_hz": 1.0,
-                }
-            }
-        }
-    else:
-        event = {
-            "type": "input_stream.set",
-            "event_data": {
-                "stream_type": "video_file_reader",
-                "stream_config": {
-                    "file_id": args["video_file_id"],
-                    "step_size": 60,
-                    "window_size": 1,
-                }
-            }
-        }
-    resp = client.lens.sessions.process_event(session_id, event)
-    logging.info(f"Stream response:\n{pformat(resp, indent=4)}")
-
-    # --- Focus & instruction
-    event = {
-        "type": "session.modify",
-        "event_data": {
-            "focus": args["focus"],
-            "max_new_tokens": 256,
-            "instruction": args["instruction"],
-        }
-    }
-    resp = client.lens.sessions.process_event(session_id, event)
-    logging.info(f"Instruction response:\n{pformat(resp, indent=4)}")
-
-    # Output stream
-    event = {
-        "type": "output_stream.set",
-        "event_data": {"stream_type": "server_side_events_writer", "stream_config": {}}
-    }
-    resp = client.lens.sessions.process_event(session_id, event)
-    logging.info(f"Output stream response:\n{pformat(resp, indent=4)}")
-
-    # --- SSE Reader
+    # Create a SSE reader to read the output of the lens.
     sse_reader = client.lens.sessions.create_sse_consumer(session_id, max_read_time_sec=args["max_run_time_sec"])
+
     for event in sse_reader.read(block=True):
         logging.info(event)
 
@@ -129,6 +84,7 @@ def session_fn(session_id, session_endpoint, client: ArchetypeAI, args: dict) ->
 
                 last_alert_state = is_alert
 
+    # Close any active reader.
     sse_reader.close()
 
 # ---------- Main ----------
@@ -163,14 +119,48 @@ def main():
         "focus": focus,
         "instruction": DEFAULT_INSTRUCTION,
         "max_run_time_sec": 600.0,
-        "api_endpoint": api_endpoint
+        "api_endpoint": api_endpoint,
+        "step_size": DEFAULT_STEP_SIZE,
+        "temporal_focus": DEFAULT_TEMPORAL_FOCUS,
+        "max_new_tokens": DEFAULT_MAX_NEW_TOKENS
     }
 
     client = ArchetypeAI(args["api_key"], api_endpoint=args["api_endpoint"])
     logging.info("▶️ Starting monitoring session…")
     send_telegram_alert("▶️ Smart monitoring started…")
 
-    client.lens.create_and_run_session(LENS_ID, session_fn, auto_destroy=True, client=client, args=args)
+    # Handle file upload if using video input
+    if input_type == "video":
+        # Note: video_file_id is expected to be already uploaded file ID
+        # If it's a file path, this would need to be modified
+        file_id = video_file_id
+        input_streams_config = f"""
+            - stream_type: video_file_reader
+              stream_config:
+                file_id: {file_id}
+                step_size: {args['step_size']}"""
+    else:
+        input_streams_config = f"""
+            - stream_type: rtsp_video_reader
+              stream_config:
+                rtsp_url: "{args['rtsp_url']}"
+                target_image_size: [360, 640]
+                target_frame_rate_hz: 1.0"""
+
+    # Create a custom lens and automatically launch the lens session.
+    client.lens.create_and_run_lens(f"""
+       lens_name: Custom Telegram Activity Monitor
+       lens_config:
+        model_parameters:
+            model_version: Newton::c2_3_7b_2508014e10af56
+            instruction: "{args['instruction']}"
+            focus: "{args['focus']}"
+            temporal_focus: {args['temporal_focus']}
+            max_new_tokens: {args['max_new_tokens']}
+        input_streams:{input_streams_config}
+        output_streams:
+            - stream_type: server_sent_events_writer
+    """, session_callback, client=client, args=args)
 
 if __name__ == "__main__":
     main()

--- a/telegram-alerts/terminal_bot/app.py
+++ b/telegram-alerts/terminal_bot/app.py
@@ -38,7 +38,6 @@ DEFAULT_INSTRUCTION = (
     "Alert: short description of what was detected, max 15 words ONLY return one of the above. "
     "Do not describe anything else."
 )
-DEFAULT_API_ENDPOINT = os.getenv("ATAI_API_ENDPOINT") or ArchetypeAI.get_default_endpoint()
 
 # ---------- Telegram Config ----------
 BOT_TOKEN = "YOUR_BOT_TOCKEN"
@@ -136,6 +135,7 @@ def session_fn(session_id, session_endpoint, client: ArchetypeAI, args: dict) ->
 def main():
     print("=== Smart Monitor Setup ===")
     api_key = os.getenv("ATAI_API_KEY", "").strip() or input("Enter your API Key: ").strip()
+    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint: ").strip()
     if not api_key:
         print("API key is required."); return
 
@@ -163,7 +163,7 @@ def main():
         "focus": focus,
         "instruction": DEFAULT_INSTRUCTION,
         "max_run_time_sec": 600.0,
-        "api_endpoint": DEFAULT_API_ENDPOINT
+        "api_endpoint": api_endpoint
     }
 
     client = ArchetypeAI(args["api_key"], api_endpoint=args["api_endpoint"])

--- a/telegram-alerts/terminal_bot/app.py
+++ b/telegram-alerts/terminal_bot/app.py
@@ -135,7 +135,7 @@ def session_fn(session_id, session_endpoint, client: ArchetypeAI, args: dict) ->
 def main():
     print("=== Smart Monitor Setup ===")
     api_key = os.getenv("ATAI_API_KEY", "").strip() or input("Enter your API Key: ").strip()
-    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint: ").strip()
+    api_endpoint = os.getenv("ATAI_API_ENDPOINT", "").strip() or input("Enter your API Endpoint (Press Enter for default): ").strip() or ArchetypeAI.get_default_endpoint()
     if not api_key:
         print("API key is required."); return
 


### PR DESCRIPTION
- Add consistent endpoint handling across all demos and examples
- Support environment variable (ATAI_API_ENDPOINT) with user input fallback
- Allow pressing Enter to use default endpoint (ArchetypeAI.get_default_endpoint())

To test:
- verify env var ATAI_API_ENDPOINT is respected when set
- confirm "enter" sets default endpoint
- confirm entering a different endpoint as input still works